### PR TITLE
twrp_TECNO-KJ6.mk

### DIFF
--- a/omni_TECNO-KJ6.mk
+++ b/omni_TECNO-KJ6.mk
@@ -9,14 +9,14 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 
-# Inherit some common Omni stuff.
-$(call inherit-product, vendor/omni/config/common.mk)
+# Inherit some common twrp stuff.
+$(call inherit-product, vendor/twrp/config/common.mk)
 
 # Inherit from TECNO-KJ6 device
 $(call inherit-product, device/tecno/TECNO-KJ6/device.mk)
 
 PRODUCT_DEVICE := TECNO-KJ6
-PRODUCT_NAME := omni_TECNO-KJ6
+PRODUCT_NAME := twrp_TECNO-KJ6
 PRODUCT_BRAND := TECNO
 PRODUCT_MODEL := TECNO KJ6
 PRODUCT_MANUFACTURER := tecno


### PR DESCRIPTION
#
# Copyright (C) 2024 The Android Open Source Project
# Copyright (C) 2024 SebaUbuntu's TWRP device tree generator
#
# SPDX-License-Identifier: Apache-2.0
#

# Inherit from those products. Most specific first.
$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
$(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)

# Inherit some common twrp stuff.
$(call inherit-product, vendor/twrp/config/common.mk)

# Inherit from KJ6 device
$(call inherit-product, device/tecno/KJ6/device.mk)

PRODUCT_DEVICE := KJ6
PRODUCT_NAME := twrp_KJ6
PRODUCT_BRAND := TECNO
PRODUCT_MODEL := TECNO KJ6
PRODUCT_MANUFACTURER := tecno

PRODUCT_GMS_CLIENTID_BASE := android-tecno

PRODUCT_BUILD_PROP_OVERRIDES += \
    PRIVATE_BUILD_DESC="vext_kj6_h897-user 12 SP1A.210812.016 482344 release-keys"

BUILD_FINGERPRINT := TECNO/KJ6-OP/TECNO-KJ6:12/SP1A.210812.016/231117V849:user/release-keys